### PR TITLE
Lighthouse create account for mainnet

### DIFF
--- a/compose-examples/lighthouse-only/create-account.yaml
+++ b/compose-examples/lighthouse-only/create-account.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   validator-import-launchpad:
     image: sigp/lighthouse:${LIGHTHOUSE_DOCKER_TAG}
-    command: lighthouse --testnet pyrmont account validator import --directory /launchpad
+    command: lighthouse --network mainnet account validator import --directory /launchpad
     volumes:
       - ./wallets:/root/.lighthouse
       - ./launchpad:/launchpad


### PR DESCRIPTION
The create account should target the mainnet not the pyrmont testnet.