### PR TITLE
Compose no-geth fixes

### DIFF
--- a/compose-examples/prysm-only/override-examples/docker-compose.beacon-validator.override.yaml
+++ b/compose-examples/prysm-only/override-examples/docker-compose.beacon-validator.override.yaml
@@ -8,15 +8,20 @@ x-disabled-service:
     entrypoint: ""
 
 services:
+  stereum-init:
+    <<: *disabled-service
   geth:
     <<: *disabled-service
   beacon:
     volumes:
       - ./config/prysm/beacon-no-geth.yaml:/config/beacon.yaml:ro
-      - ./data/prysm/beacon:/data
   slasher:
     <<: *disabled-service
   prometheus:
     <<: *disabled-service
   grafana:
+    <<: *disabled-service
+  renderer:
+    <<: *disabled-service
+  node-exporter:
     <<: *disabled-service


### PR DESCRIPTION
1. Add new services to disabled services.
2. Use the same data folder for the beacon service from the main docker-compose.yaml
   This is very useful when coming from a regular deployment where the data folder will reside on beacon-slasher (for example).